### PR TITLE
fix: correct hangman drawing sequence order

### DIFF
--- a/script.js
+++ b/script.js
@@ -277,13 +277,12 @@ function updateLives() {
 }
 
 function updateHangman() {
-    const parts = ['head', 'body', 'leftArm', 'rightArm', 'leftLeg', 'rightLeg'];
-    
-    const wrongOrder = ['head', 'leftArm', 'rightArm', 'body', 'leftLeg', 'rightLeg'];
+    // Correct sequence: head → body → left arm → right arm → left leg → right leg
+    const correctOrder = ['head', 'body', 'leftArm', 'rightArm', 'leftLeg', 'rightLeg'];
     const partIndex = gameState.wrongGuesses - 1;
     
-    if (partIndex >= 0 && partIndex < wrongOrder.length) {
-        const partToShow = wrongOrder[partIndex];
+    if (partIndex >= 0 && partIndex < correctOrder.length) {
+        const partToShow = correctOrder[partIndex];
         document.getElementById(partToShow).style.display = 'block';
     }
 }


### PR DESCRIPTION
Fixed the hangman body parts drawing sequence from incorrect order (head, leftArm, rightArm, body, leftLeg, rightLeg) to the standard sequence (head, body, leftArm, rightArm, leftLeg, rightLeg). Renamed variable from 'wrongOrder' to 'correctOrder' for clarity.