### PR TITLE
fix: display only wrong letters in Wrong Guesses section

### DIFF
--- a/script.js
+++ b/script.js
@@ -268,7 +268,7 @@ function updateWrongLetters() {
     if (wrong.length === 0) {
         wrongLettersDiv.textContent = 'None yet';
     } else {
-        wrongLettersDiv.textContent = gameState.guessedLetters.join(', ');
+        wrongLettersDiv.textContent = wrong.join(', ');
     }
 }
 


### PR DESCRIPTION
Fixed bug where all guessed letters were displayed in Wrong Guesses instead of only the incorrect ones. Changed from displaying gameState.guessedLetters to displaying the filtered 'wrong' array which contains only letters not in the current word.